### PR TITLE
Add reset timers feature 

### DIFF
--- a/Source/EyesGuard.Data/Languages/en-US.yml
+++ b/Source/EyesGuard.Data/Languages/en-US.yml
@@ -142,6 +142,7 @@ Translation:
         - In this mode, Eyes Guard automatically pauses down-counting.
         - Notice that this feature can disable guarding your eyes when you are not
           interacting with your PC, for example when watching movies.
+        ResetTimersAfterIdleGap: 'Reset timers when system goes to idle mode exceeds:'
       StatsSettings:
         Title: Stats
         YesDeleteData: Yes, Sure

--- a/Source/EyesGuard.Data/Languages/zh-CN.yml
+++ b/Source/EyesGuard.Data/Languages/zh-CN.yml
@@ -4,7 +4,11 @@ Meta:
   - Name: 七夕泥
     GitHubUsername: Qixiny
     Website: https://github.com/Qxiny
-    Notes: '第一次翻译软件请多多指教，翻译的有些太可爱了~ 邮箱:3185835784@qq.com'  
+    Notes: '第一次翻译软件请多多指教，翻译的有些太可爱了~ 邮箱:3185835784@qq.com'
+  - Name: 0ow
+    GitHubUsername: z0ow
+    Website: https://github.com/z0ow
+    Notes: '新增计时器重置翻译选项（仅中文）'
 
 Translation:
   Application:
@@ -113,6 +117,7 @@ Translation:
         ShortBreakAllowCloseWithRightCLick: 鼠标右键关闭让你去小型休息的提示
         ShortBreakAllowCloseWithRightCLickToolTip: 允许你在那个烦人的窗口跳出来的时候右键把它关掉（然后你的眼睛就......）
         SystemIdle: 你不动电脑的时候护眼姬自动帮你暂停
+        ResetTimersAfterIdleGap: '当系统空闲超过该时间后重置所有计时器:'
         SystemIdleToolTip:
         - 当你不动电脑的时候将会自动暂停休息系统
         - 例如你电脑搁着忘关了，或者是在看电影

--- a/Source/EyesGuard/App.Initialization.xaml.cs
+++ b/Source/EyesGuard/App.Initialization.xaml.cs
@@ -152,8 +152,7 @@ namespace EyesGuard
                 SystemIdleDetector = new IdleDetector()
                 {
                     IdleThreshold = EyesGuardIdleDetectionThreshold,
-                    DeferUpdate = false,
-                    EnableRaisingEvents = initialStart
+                    DeferUpdate = false
                 };
                 SystemIdleDetector.IdleStateChanged += SystemIdleDetector_IdleStateChanged;
 

--- a/Source/EyesGuard/App.Initialization.xaml.cs
+++ b/Source/EyesGuard/App.Initialization.xaml.cs
@@ -35,7 +35,7 @@ namespace EyesGuard
                 Shutdown();
             }
 
-            InitializeIdleDetector(Configuration.SystemIdleDetectionEnabled);
+            InitializeIdleDetector(Configuration.SystemIdleDetectionEnabled | Configuration.EnableResetTimerAfterIdleDuration);
 
             ToolTipService.ShowDurationProperty.OverrideMetadata(
                 typeof(DependencyObject), new FrameworkPropertyMetadata(int.MaxValue));
@@ -166,6 +166,20 @@ namespace EyesGuard
         private void SystemIdleDetector_IdleStateChanged(object sender, IdleStateChangedEventArgs e)
         {
             UpdateIdleActions();
+
+            if (App.Configuration.EnableResetTimerAfterIdleDuration &&
+                !CheckIfResting(showWarning: false) &&
+                e.IdleState &&
+                e.Duration > App.Configuration.ResetTimersAfterIdleDuration.TotalSeconds)
+            {
+                ShortBreakHandler.Stop();
+                LongBreakHandler.Stop();
+                NextShortBreak = App.Configuration.ShortBreakGap;
+                NextLongBreak = App.Configuration.LongBreakGap;
+                ShortBreakHandler.Start();
+                LongBreakHandler.Start();
+            }
+
         }
 
         public static void UpdateIdleActions()

--- a/Source/EyesGuard/App.Properties.xaml.cs
+++ b/Source/EyesGuard/App.Properties.xaml.cs
@@ -40,7 +40,6 @@ namespace EyesGuard
                     .ShortLongBreakTimeRemaining
                     .IsProtectionPaused = value;
                 UIViewModels.NotifyIcon.PausedVisibility = value ? Visibility.Visible : Visibility.Collapsed;
-                SystemIdleDetector.EnableRaisingEvents = !value;
             }
         }
 

--- a/Source/EyesGuard/Configurations/ConfigurationProperties.cs
+++ b/Source/EyesGuard/Configurations/ConfigurationProperties.cs
@@ -17,6 +17,7 @@ namespace EyesGuard.Configurations
         private bool _keyTimeVisible = true;
         private bool runAtStartup = false;
         private bool _systemIdleDetectionEnabled = false;
+        private bool _enableResetTimerAfterIdleDuration = false;
         #endregion
 
         #region Config :: Fields :: Public Properties
@@ -108,6 +109,36 @@ namespace EyesGuard.Configurations
                     }
                 }
             }
+        }
+
+        public bool EnableResetTimerAfterIdleDuration
+        {
+            get => _enableResetTimerAfterIdleDuration;
+            set
+            {
+                _enableResetTimerAfterIdleDuration = value;
+
+                if (SystemIdleDetector != null)
+                {
+                    if (value && SystemIdleDetector.State == IdleDetectorState.Stopped)
+                    {
+                        _ = SystemIdleDetector.RequestStart();
+                    }
+                    else if (!value && SystemIdleDetector.State == IdleDetectorState.Running)
+                    {
+                        _ = SystemIdleDetector.RequestCancel();
+                    }
+                }
+            }
+        }
+
+        [XmlIgnore]
+        public TimeSpan ResetTimersAfterIdleDuration { get; set; } = new TimeSpan(0, 45, 0);
+
+        public string ResetTimersAfterIdleGapString
+        {
+            get { return ResetTimersAfterIdleDuration.ToString(); }
+            set { ResetTimersAfterIdleDuration = TimeSpan.Parse(value); }
         }
 
         public string ApplicationLocale { get; set; } = FsLanguageLoader.DefaultLocale;

--- a/Source/EyesGuard/IdleDetector.cs
+++ b/Source/EyesGuard/IdleDetector.cs
@@ -16,6 +16,7 @@ namespace EyesGuard
     public class IdleStateChangedEventArgs : EventArgs
     {
         public bool IdleState { get; set; }
+        public long Duration { get; set; }
     }
 
     public class IdleDetector
@@ -55,6 +56,7 @@ namespace EyesGuard
             LASTINPUTINFO lastInPut = new LASTINPUTINFO();
             lastInPut.cbSize = (uint)Marshal.SizeOf(lastInPut);
             State = IdleDetectorState.Running;
+            int lastTriggerTime = Environment.TickCount;
 
             while (!cancelRequested)
             {
@@ -71,8 +73,14 @@ namespace EyesGuard
 
                 if (EnableRaisingEvents && (IsSystemIdle() != previousSystemInputIdle))
                 {
+                    IdleStateChangedEventArgs lastEventStateArgs = new IdleStateChangedEventArgs()
+                    {
+                        IdleState = previousSystemInputIdle,
+                        Duration = (Environment.TickCount - lastTriggerTime) / 1000
+                    };
+                    lastTriggerTime = Environment.TickCount;
                     previousSystemInputIdle = IsSystemIdle();
-                    IdleStateChanged?.Invoke(null, null);
+                    IdleStateChanged?.Invoke(null, lastEventStateArgs);
                 }
                 await Task.Delay(UpdateInterval);
             }

--- a/Source/EyesGuard/IdleDetector.cs
+++ b/Source/EyesGuard/IdleDetector.cs
@@ -40,8 +40,6 @@ namespace EyesGuard
 
         private bool cancelRequested = false;
 
-        public bool EnableRaisingEvents { get; set; } = false;
-
         public event EventHandler<IdleStateChangedEventArgs> IdleStateChanged;
 
         internal struct LASTINPUTINFO
@@ -66,12 +64,12 @@ namespace EyesGuard
                 }
                 catch
                 {
-                    EnableRaisingEvents = false;
                     break;
                 }
                 IdleDuration = (Environment.TickCount - lastInPut.dwTime) / 1000;
 
-                if (EnableRaisingEvents && (IsSystemIdle() != previousSystemInputIdle))
+                if ((App.Configuration.ProtectionState == App.GuardStates.Protecting) &&
+                    (IsSystemIdle() != previousSystemInputIdle))
                 {
                     IdleStateChangedEventArgs lastEventStateArgs = new IdleStateChangedEventArgs()
                     {

--- a/Source/EyesGuard/Views/Pages/Settings.xaml
+++ b/Source/EyesGuard/Views/Pages/Settings.xaml
@@ -300,14 +300,16 @@
                         <RowDefinition />
                         <RowDefinition />
                         <RowDefinition />
+                        <RowDefinition />
                         <RowDefinition Height="10" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="15" />
+                        <ColumnDefinition Width="auto" />
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
                     <Border
-                        Grid.RowSpan="7"
+                        Grid.RowSpan="8"
                         Grid.Column="0"
                         Margin="6,-0.5,0,0"
                         BorderBrush="White"
@@ -333,6 +335,7 @@
                     <StackPanel
                         Grid.Row="2"
                         Grid.Column="1"
+                        Grid.ColumnSpan="2"
                         Margin="5"
                         Orientation="Horizontal">
                         <CheckBox
@@ -348,6 +351,7 @@
                     <StackPanel
                         Grid.Row="3"
                         Grid.Column="1"
+                        Grid.ColumnSpan="2"
                         Margin="5"
                         Orientation="Horizontal">
                         <CheckBox
@@ -361,7 +365,8 @@
 
                     <StackPanel
                         Grid.Row="4"
-                        Grid.Column="2"
+                        Grid.Column="1"
+                        Grid.ColumnSpan="2"
                         Margin="5"
                         Orientation="Horizontal"
                         ToolTip="{lang:LocalizedString 'EyesGuard.Settings.UserSettings.StartupApplicationToolTip'}">
@@ -379,7 +384,8 @@
 
                     <StackPanel
                         Grid.Row="5"
-                        Grid.Column="2"
+                        Grid.Column="1"
+                        Grid.ColumnSpan="2"
                         Margin="5"
                         Orientation="Horizontal">
                         <CheckBox
@@ -391,11 +397,72 @@
                             ToolTip="{lang:LocalizedString 'EyesGuard.Settings.UserSettings.SystemIdleToolTipJoined'}" />
 
                     </StackPanel>
-                    <StackPanel
+                    <CheckBox
                         Grid.Row="6"
                         Grid.Column="1"
                         Margin="5"
-                        Orientation="Horizontal">
+                            x:Name="resetTimersAfterIdleDurationCheckbox"
+                            VerticalAlignment="Center"
+                            Checked="resetTimersAfterIdleDurationCheckbox_Checked"
+                            Unchecked="resetTimersAfterIdleDurationCheckbox_Unchecked"
+                            Content="{lang:LocalizedString 'EyesGuard.Settings.UserSettings.ResetTimersAfterIdleGap'}"
+                            Foreground="White"
+                            IsChecked="False"
+                            Style="{DynamicResource WhiteCheckbox}" />
+                    <StackPanel 
+                        x:Name="resetTimersAfterIdleGapInputStack"
+                        Grid.Row="6" 
+                        Grid.Column="2"
+                        Margin="5"
+                        Orientation="Horizontal"
+                        IsEnabled="False">
+                        <c:NumOnlyTextbox
+                            x:Name="resetTimersAfterIdleDurationHours"
+                            MinWidth="50"
+                            Margin="10,0,0,0"
+                            MaxLength="2"
+                            Style="{DynamicResource WhiteTextBox}"
+                            Text="0"
+                            TextAlignment="Center" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Foreground="White"
+                            Text="{lang:LocalizedString 'EyesGuard.Settings.TimeSeparators.Hour'}" />
+                        <c:NumOnlyTextbox
+                            x:Name="resetTimersAfterIdleDurationMinutes"
+                            MinWidth="50"
+                            Margin="5,0,0,0"
+                            MaxLength="2"
+                            Style="{DynamicResource WhiteTextBox}"
+                            Text="0"
+                            TextAlignment="Center" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Foreground="White"
+                            Text="{lang:LocalizedString 'EyesGuard.Settings.TimeSeparators.Minutes'}" />
+                        <c:NumOnlyTextbox
+                            x:Name="resetTimersAfterIdleDurationSeconds"
+                            MinWidth="50"
+                            Margin="5,0,0,0"
+                            MaxLength="2"
+                            Style="{DynamicResource WhiteTextBox}"
+                            Text="0"
+                            TextAlignment="Center" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Foreground="White"
+                            Text="{lang:LocalizedString 'EyesGuard.Settings.TimeSeparators.Second'}" />
+
+                    </StackPanel>
+                    <StackPanel
+                        Grid.Row="7"
+                        Grid.Column="1"
+                        Margin="5"
+                        Orientation="Horizontal"
+                        Grid.ColumnSpan="2">
                         <CheckBox
                             x:Name="shortBreakAllowCloseWithRightCLick"
                             VerticalAlignment="Center"

--- a/Source/EyesGuard/Views/Pages/Settings.xaml.cs
+++ b/Source/EyesGuard/Views/Pages/Settings.xaml.cs
@@ -87,6 +87,11 @@ namespace EyesGuard.Views.Pages
 
             sytemIdleCheckbox.IsChecked = App.Configuration.SystemIdleDetectionEnabled;
 
+            resetTimersAfterIdleDurationCheckbox.IsChecked = App.Configuration.EnableResetTimerAfterIdleDuration;
+            resetTimersAfterIdleDurationHours.Text = App.Configuration.ResetTimersAfterIdleDuration.Hours.ToString();
+            resetTimersAfterIdleDurationMinutes.Text = App.Configuration.ResetTimersAfterIdleDuration.Minutes.ToString();
+            resetTimersAfterIdleDurationSeconds.Text = App.Configuration.ResetTimersAfterIdleDuration.Seconds.ToString();
+
             UseLanguageAsSourceCheckbox.IsChecked = App.Configuration.UseLanguageProvedidShortMessages;
         }
 
@@ -125,7 +130,8 @@ namespace EyesGuard.Views.Pages
                 // sd: Short Duration
                 // lg: Long Gap
                 // ld: Long Duration
-                int sgH, sgM, sgS, sdH, sdM, sdS, lgH, lgM, lgS, ldH, ldM, ldS;
+                // rd: Reset Duration
+                int sgH, sgM, sgS, sdH, sdM, sdS, lgH, lgM, lgS, ldH, ldM, ldS, rdH, rdM, rdS;
 
                 sgH = int.Parse(shortGapHours.Text);
                 sgM = int.Parse(shortGapMinutes.Text);
@@ -142,6 +148,10 @@ namespace EyesGuard.Views.Pages
                 ldH = int.Parse(longDurationHours.Text);
                 ldM = int.Parse(longDurationMinutes.Text);
                 ldS = int.Parse(longDurationSeconds.Text);
+
+                rdH = int.Parse(resetTimersAfterIdleDurationHours.Text);
+                rdM = int.Parse(resetTimersAfterIdleDurationMinutes.Text);
+                rdS = int.Parse(resetTimersAfterIdleDurationSeconds.Text);
 
                 if (sgH > 11 || sdH > 11 || lgH > 11 || ldH > 11)
                     warning += "» " + App.LocalizedEnvironment.Translation.EyesGuard.TimeManipulation.HoursLimit.FormatWith(new { Hours = 11 });
@@ -217,6 +227,8 @@ namespace EyesGuard.Views.Pages
                     App.Configuration.AlertBeforeLongBreak = alertBeforeLongbreak.IsChecked.Value;
                     App.Configuration.ShortBreakAllowCloseWithRightCLick = shortBreakAllowCloseWithRightCLick.IsChecked.Value;
                     App.Configuration.SystemIdleDetectionEnabled = sytemIdleCheckbox.IsChecked.Value;
+                    App.Configuration.EnableResetTimerAfterIdleDuration = resetTimersAfterIdleDurationCheckbox.IsChecked.Value;
+                    App.Configuration.ResetTimersAfterIdleDuration = new TimeSpan(rdH, rdM, rdS);
                     App.Configuration.ApplicationLocale = (LanguagesCombo.SelectedItem as LanguageHolder)?.Name ?? FsLanguageLoader.DefaultLocale;
                     App.Configuration.UseLanguageProvedidShortMessages = UseLanguageAsSourceCheckbox.IsChecked.Value;
 
@@ -363,6 +375,16 @@ namespace EyesGuard.Views.Pages
         private void forceUserCheckbox_Unchecked(object sender, RoutedEventArgs e)
         {
             shortBreakAllowCloseWithRightCLick.IsEnabled = true;
+        }
+        
+        private void resetTimersAfterIdleDurationCheckbox_Checked(object sender, RoutedEventArgs e)
+        {
+            resetTimersAfterIdleGapInputStack.IsEnabled = true;
+        }
+
+        private void resetTimersAfterIdleDurationCheckbox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            resetTimersAfterIdleGapInputStack.IsEnabled = false;
         }
     }
 }


### PR DESCRIPTION
---
name: Bug Report
about: Report a bug to the Eyes Guard community
---

**Description**
1. Add a feature corresponding to issue #40
2. Use App.Configuration.ProtectionState as a condition to raise the IdleChanged event, then remove the EnableRaisingEvents property. The past logic will make this event could not be triggered if the application starts with initialStart==false.
3. Add a Chinese translation that is related to this feature.

**PR Domain**
Which change are you proposing?

Make users can prefer to reset short and long break timers by idle duration.

- [+] Add feature
- [ ] Fix bug
- [ ] Fix Typo
- [ ] Extend support

**Issue relation**
This PR is related to issue #40

**Screenshots**
![image](https://github.com/avestura/EyesGuard/assets/20352723/2a2bb7e8-50c8-4ef8-954c-80f936ebfe17)

**Additional context**
[Add any other context about the problem here.]